### PR TITLE
Update Next.js version in docs

### DIFF
--- a/DEV_LOG_TECHNICAL.md
+++ b/DEV_LOG_TECHNICAL.md
@@ -6,7 +6,7 @@
 - Forked from context-engineering-intro template
 - Project structure:
   - `/band-platform/backend/` - FastAPI application with existing scaffolding
-  - `/band-platform/frontend/` - Next.js 14 with TypeScript and Tailwind
+  - `/band-platform/frontend/` - Next.js 15 with TypeScript and Tailwind
   - Docker Compose configuration for containerized development
 
 ### Architecture Baseline

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ docker-compose up
 ## 🏗️ Architecture
 
 - **Backend**: FastAPI (Python) with async support
-- **Frontend**: Next.js 14 with TypeScript and Tailwind CSS
+- **Frontend**: Next.js 15 with TypeScript and Tailwind CSS
 - **Database**: PostgreSQL
 - **File Storage**: Google Drive integration
 - **Authentication**: JWT tokens with Google OAuth planned


### PR DESCRIPTION
## Summary
- bump architecture section to Next.js 15
- update technical log to reflect Next.js 15

## Testing
- `pip install -r requirements.txt`
- `pip install pyjwt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68897d7d40148330ae39ca4917d40ec2