### PR TITLE
Rename database hook

### DIFF
--- a/band-platform/backend/app/database/connection.py
+++ b/band-platform/backend/app/database/connection.py
@@ -80,9 +80,9 @@ def create_database_engine() -> AsyncEngine:
     
     # Add event listeners for connection lifecycle
     @event.listens_for(engine.sync_engine, "connect")
-    def set_sqlite_pragma(dbapi_connection, connection_record):
+    def set_postgresql_settings(dbapi_connection, connection_record):
         """Set PostgreSQL-specific connection parameters."""
-        # This is for PostgreSQL, not SQLite
+        # This function is intentionally left blank for now
         pass
     
     @event.listens_for(engine.sync_engine, "checkout")
@@ -314,6 +314,6 @@ class DatabaseManager:
 # During unit tests the database is usually mocked, so failure to create the
 # manager here should not raise an exception. Tests patch this attribute.
 try:
-    db_manager = DatabaseManager()
+    db_manager: Optional[DatabaseManager] = DatabaseManager()
 except RuntimeError:
     db_manager = None

--- a/band-platform/backend/app/services/websocket_manager.py
+++ b/band-platform/backend/app/services/websocket_manager.py
@@ -1,0 +1,17 @@
+"""WebSocket manager for broadcasting real-time updates."""
+
+from typing import Any
+
+
+class WebSocketManager:
+    """Minimal WebSocket manager used in tests."""
+
+    async def broadcast_to_band(self, band_id: int, message: Any) -> None:
+        """Broadcast a message to all band members.
+
+        In the real application this would forward the message to connected
+        WebSocket clients. The test suite mocks this method.
+        """
+
+        # Placeholder implementation for tests
+        return None


### PR DESCRIPTION
## Summary
- rename `set_sqlite_pragma` to `set_postgresql_settings`
- adjust db manager typing
- provide a basic `websocket_manager` for tests
- patch database session helper in tests

## Testing
- `ruff check band-platform/backend/app/services/websocket_manager.py`
- `ruff check band-platform/backend/conftest.py --fix`
- `PYTHONPATH=. mypy app/database/connection.py app/services/websocket_manager.py --explicit-package-bases`
- `PYTHONPATH=band-platform/backend pytest band-platform/backend/tests -q` *(fails: 28 failed, 130 passed, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68897d7f0c80833086521849cd55f188