### PR TITLE
Set Inter font globally

### DIFF
--- a/band-platform/frontend/src/app/globals.css
+++ b/band-platform/frontend/src/app/globals.css
@@ -22,5 +22,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Inter", Arial, Helvetica, sans-serif;
 }


### PR DESCRIPTION
## Summary
- use the Inter Google font in `globals.css` to match the layout

## Testing
- `npm test` *(fails: Unable to find a label with text "Toggle navigation menu")*
- `npm run build` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6889808bdf9c8330b7eb23504d8de5a3