### PR TITLE
Add settings route and persistent UI preferences

### DIFF
--- a/band-platform/frontend/src/__tests__/components/Layout.test.tsx
+++ b/band-platform/frontend/src/__tests__/components/Layout.test.tsx
@@ -55,6 +55,7 @@ describe('Layout', () => {
     expect(screen.getByText('Audio')).toBeInTheDocument()
     expect(screen.getByText('Setlists')).toBeInTheDocument()
     expect(screen.getByText('Band')).toBeInTheDocument()
+    expect(screen.getByText('Settings')).toBeInTheDocument()
   })
 
   it('renders children content', () => {
@@ -91,6 +92,7 @@ describe('Layout', () => {
     expect(screen.getAllByText('Charts')).toHaveLength(2)
     expect(screen.getAllByText('Audio')).toHaveLength(2)
     expect(screen.getAllByText('Setlists')).toHaveLength(2)
+    expect(screen.getAllByText('Settings')).toHaveLength(2)
   })
 
   it('toggles dark mode when button is clicked', async () => {

--- a/band-platform/frontend/src/app/globals.css
+++ b/band-platform/frontend/src/app/globals.css
@@ -3,6 +3,7 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --scale: 1;
 }
 
 @theme inline {
@@ -23,4 +24,8 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+}
+
+html {
+  font-size: calc(16px * var(--scale));
 }

--- a/band-platform/frontend/src/app/settings/page.tsx
+++ b/band-platform/frontend/src/app/settings/page.tsx
@@ -1,0 +1,63 @@
+'use client';
+import { useState, useEffect } from 'react';
+
+export default function SettingsPage() {
+  const [darkMode, setDarkMode] = useState(false);
+  const [scale, setScale] = useState('1');
+
+  useEffect(() => {
+    const theme = localStorage.getItem('theme');
+    const savedScale = localStorage.getItem('scale');
+    if (theme === 'dark') {
+      setDarkMode(true);
+    }
+    if (savedScale) {
+      setScale(savedScale);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (darkMode) {
+      document.documentElement.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    }
+  }, [darkMode]);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty('--scale', scale);
+    localStorage.setItem('scale', scale);
+  }, [scale]);
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold">Settings</h1>
+      <div className="flex items-center space-x-2">
+        <input
+          id="darkMode"
+          type="checkbox"
+          checked={darkMode}
+          onChange={() => setDarkMode(!darkMode)}
+        />
+        <label htmlFor="darkMode">Dark Mode</label>
+      </div>
+      <div>
+        <label htmlFor="scale" className="block mb-1">
+          Interface Scale
+        </label>
+        <select
+          id="scale"
+          value={scale}
+          onChange={(e) => setScale(e.target.value)}
+          className="text-black p-1 border rounded"
+        >
+          <option value="0.875">Small</option>
+          <option value="1">Medium</option>
+          <option value="1.25">Large</option>
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/band-platform/frontend/src/components/Layout.tsx
+++ b/band-platform/frontend/src/components/Layout.tsx
@@ -9,17 +9,19 @@ import {
   MusicalNoteIcon,
   ListBulletIcon,
   UserGroupIcon,
+  Cog6ToothIcon,
   MoonIcon,
   SunIcon,
   Bars3Icon,
   XMarkIcon,
 } from '@heroicons/react/24/outline';
-import { 
+import {
   HomeIcon as HomeIconSolid,
   DocumentTextIcon as DocumentTextIconSolid,
   MusicalNoteIcon as MusicalNoteIconSolid,
   ListBulletIcon as ListBulletIconSolid,
   UserGroupIcon as UserGroupIconSolid,
+  Cog6ToothIcon as Cog6ToothIconSolid,
 } from '@heroicons/react/24/solid';
 
 interface LayoutProps {
@@ -39,20 +41,27 @@ const navigation: NavItem[] = [
   { name: 'Audio', href: '/audio', icon: MusicalNoteIcon, iconSolid: MusicalNoteIconSolid },
   { name: 'Setlists', href: '/setlists', icon: ListBulletIcon, iconSolid: ListBulletIconSolid },
   { name: 'Band', href: '/band', icon: UserGroupIcon, iconSolid: UserGroupIconSolid },
+  { name: 'Settings', href: '/settings', icon: Cog6ToothIcon, iconSolid: Cog6ToothIconSolid },
 ];
 
 export default function Layout({ children }: LayoutProps) {
   const pathname = usePathname();
   const [isDarkMode, setIsDarkMode] = useState(false);
+  const [scale, setScale] = useState(1);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isOnline, setIsOnline] = useState(true);
 
-  // Initialize theme from localStorage or system preference
+  // Initialize theme and scale from localStorage or system preference
   useEffect(() => {
     const savedTheme = localStorage.getItem('theme');
+    const savedScale = localStorage.getItem('scale');
     if (savedTheme === 'dark' || (!savedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
       setIsDarkMode(true);
       document.documentElement.classList.add('dark');
+    }
+    if (savedScale) {
+      setScale(parseFloat(savedScale));
+      document.documentElement.style.setProperty('--scale', savedScale);
     }
   }, []);
 
@@ -66,6 +75,12 @@ export default function Layout({ children }: LayoutProps) {
       localStorage.setItem('theme', 'light');
     }
   }, [isDarkMode]);
+
+  // Update interface scale
+  useEffect(() => {
+    document.documentElement.style.setProperty('--scale', scale.toString());
+    localStorage.setItem('scale', scale.toString());
+  }, [scale]);
 
   // Monitor online/offline status
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add `src/app/settings` route
- persist `theme` and `scale` preferences in `localStorage`
- read `scale` in layout and apply via CSS variable
- add "Settings" to navigation list
- update layout tests

## Testing
- `npm run lint` *(fails: A `require()` style import is forbidden, Unexpected any, etc.)*
- `npm test` *(fails: various tests fail to run due to module mapping issues)*

------
https://chatgpt.com/codex/tasks/task_e_688980e3167c83309097bb6e4455b1fe