### PR TITLE
Add missing WebSocket manager and clean imports

### DIFF
--- a/DEV_LOG.md
+++ b/DEV_LOG.md
@@ -147,3 +147,11 @@ At the end of this session, two final important system improvements were impleme
 **Platform Status**: Production Ready
 **Documentation System**: Fully chronological with prompt tracking
 **Next Session**: Will continue from production-ready platform with new documentation standards
+
+## Session 4 - July 31, 2025
+
+### What's New
+- Added missing `.env.example` for the frontend with `NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_WS_URL` variables.
+- Fixed backend `.env.example` and included `JWT_SECRET_KEY` placeholder.
+- Updated documentation to explain new environment variables.
+- Marked the open task as complete in `TASK.md`.

--- a/DEV_LOG_TECHNICAL.md
+++ b/DEV_LOG_TECHNICAL.md
@@ -352,3 +352,11 @@ The following technical implementations were triggered by specific user requests
 - UI: Professional with musical notation and custom typography
 - Documentation: Chronological system with prompt tracking
 - Codebase: Production-ready with all features implemented
+
+## Session 4 - July 31, 2025
+
+### Implementation Details
+- Created `band-platform/frontend/.env.example` with example API URLs.
+- Cleaned up `band-platform/backend/.env.example` and added `JWT_SECRET_KEY`.
+- Documented environment setup changes in `README.md` and `README_SECURITY.md`.
+- Completed the environment file task and updated `TASK.md` accordingly.

--- a/README.md
+++ b/README.md
@@ -27,13 +27,17 @@ python -m venv venv_linux
 source venv_linux/bin/activate  # On Windows: venv_linux\Scripts\activate
 pip install -r requirements.txt
 cp .env.example .env
-# Edit .env with your configuration
+# Edit .env with your configuration (Google OAuth and JWT settings)
 
 # Frontend setup
 cd ../frontend
 npm install
 cp .env.example .env.local
-# Edit .env.local with your configuration
+# Edit .env.local with your configuration (frontend API endpoints)
+
+The `.env` file requires your Google OAuth credentials and a `JWT_SECRET_KEY` for
+token signing. The frontend `.env.local` file exposes `NEXT_PUBLIC_API_URL` and
+`NEXT_PUBLIC_WS_URL` so the UI can communicate with the backend.
 
 # Run with Docker Compose (from project root)
 docker-compose up

--- a/TASK.md
+++ b/TASK.md
@@ -1,14 +1,14 @@
 # Soleil Band Platform - Task Tracking
 
-## Current Tasks (2025-07-30)
+## Current Tasks (2025-07-31)
 
 ### Session Summary
 **Session 3 Complete**: Production-ready platform with 247 songs, professional UI, and complete documentation system
 
 ### Active
-- [ ] Create missing environment files (.env.example files) (added 2025-07-28)
 
-### Just Completed (2025-07-30)
+### Just Completed (2025-07-31)
+- [x] Create missing environment files (.env.example files) (completed 2025-07-31)
 - [x] Create chronological documentation system with user prompt references (completed 2025-07-30)
   - User: "all updates to root folder documentation should be formatted in chronological format... be sure to include specific refences to my prompts within our conversation"
   - Created DOCUMENTATION_INDEX.md to track all versions

--- a/band-platform/backend/.env.example
+++ b/band-platform/backend/.env.example
@@ -5,4 +5,5 @@ GOOGLE_REDIRECT_URI=http://localhost:8000/api/auth/google/callback
 
 # Google Drive Configuration
 GOOGLE_DRIVE_SOURCE_FOLDER_ID=your_drive_folder_id_here
-EOF < /dev/null
+JWT_SECRET_KEY=your_jwt_secret_key_here
+

--- a/band-platform/backend/README_SECURITY.md
+++ b/band-platform/backend/README_SECURITY.md
@@ -14,6 +14,7 @@ For security reasons, OAuth credentials and API keys are not included in the rep
    - `GOOGLE_CLIENT_SECRET`: Your Google OAuth2 client secret
    - `GOOGLE_REDIRECT_URI`: Should be `http://localhost:8000/api/auth/google/callback` for local development
    - `GOOGLE_DRIVE_SOURCE_FOLDER_ID`: The ID of your Google Drive folder containing charts
+   - `JWT_SECRET_KEY`: Secret key for signing JWT tokens
 
 ## Files Not in Repository
 

--- a/band-platform/backend/app/api/google_auth.py
+++ b/band-platform/backend/app/api/google_auth.py
@@ -3,8 +3,7 @@ Google OAuth2 authentication endpoints.
 Allows admin to authenticate once, then all users benefit from the connection.
 """
 
-from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import RedirectResponse
+from fastapi import APIRouter, HTTPException
 import logging
 
 from ..services.google_drive_oauth import drive_oauth_service

--- a/band-platform/backend/app/database/migrations/add_folder_structure.py
+++ b/band-platform/backend/app/database/migrations/add_folder_structure.py
@@ -10,7 +10,6 @@ Created: 2025-07-28
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 
 def upgrade():

--- a/band-platform/backend/app/services/google_drive_oauth.py
+++ b/band-platform/backend/app/services/google_drive_oauth.py
@@ -4,11 +4,7 @@ This is more secure than service account keys and works with organization polici
 """
 
 import os
-import json
 from typing import Optional, List, Dict, Any
-from datetime import datetime
-import asyncio
-from functools import lru_cache
 
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials

--- a/band-platform/backend/app/services/google_sheets.py
+++ b/band-platform/backend/app/services/google_sheets.py
@@ -7,8 +7,8 @@ for real-time setlist management and gig scheduling with proper timezone support
 
 import asyncio
 import logging
-from datetime import datetime, timezone, timedelta
-from typing import Dict, List, Optional, Any, Tuple
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Any
 from contextlib import asynccontextmanager
 
 from google.auth.transport.requests import Request
@@ -18,7 +18,6 @@ from googleapiclient.errors import HttpError
 import backoff
 import pytz
 
-from ..config import settings
 
 logger = logging.getLogger(__name__)
 

--- a/band-platform/backend/app/services/websocket_manager.py
+++ b/band-platform/backend/app/services/websocket_manager.py
@@ -1,0 +1,11 @@
+"""Simple WebSocket manager stub for tests."""
+
+from typing import Any
+
+class WebSocketManager:
+    """Manage WebSocket connections for broadcasting."""
+
+    async def broadcast_to_band(self, band_id: int, message: Any) -> None:
+        """Broadcast a message to all connections for a band."""
+        # In tests we just record the call via mocks
+        pass

--- a/band-platform/frontend/.env.example
+++ b/band-platform/frontend/.env.example
@@ -1,0 +1,4 @@
+# Frontend Environment Configuration
+NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_WS_URL=ws://localhost:8000/ws
+

--- a/band-platform/frontend/.gitignore
+++ b/band-platform/frontend/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
## Summary
- fix unused imports flagged by ruff
- add a minimal `websocket_manager` service so sync tests import successfully
- install missing test dependencies in venv and run quality checks

## Testing
- `ruff app`
- `mypy --explicit-package-bases app` *(fails: 150 errors)*
- `PYTHONPATH=. pytest -q` *(fails: 28 failed, 130 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688979a2cccc8330b3ae363f88dc871c