### PR TITLE
Remove extraneous EOF from env example

### DIFF
--- a/band-platform/backend/.env.example
+++ b/band-platform/backend/.env.example
@@ -5,4 +5,3 @@ GOOGLE_REDIRECT_URI=http://localhost:8000/api/auth/google/callback
 
 # Google Drive Configuration
 GOOGLE_DRIVE_SOURCE_FOLDER_ID=your_drive_folder_id_here
-EOF < /dev/null


### PR DESCRIPTION
## Summary
- clean up trailing line in `.env.example`

## Testing
- `PYTHONPATH=band-platform/backend pytest -q` *(fails: RuntimeError: Database not initialized, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688a24d152a08330914d318ee18dbba2