### PR TITLE
Add frontend env example

### DIFF
--- a/band-platform/frontend/.env.example
+++ b/band-platform/frontend/.env.example
@@ -1,0 +1,4 @@
+# Example environment variables for the Next.js frontend
+NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_WS_URL=ws://localhost:8000/ws
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=your_google_client_id_here

--- a/band-platform/frontend/.gitignore
+++ b/band-platform/frontend/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/band-platform/frontend/README.md
+++ b/band-platform/frontend/README.md
@@ -20,6 +20,16 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Environment Variables
+
+Copy `.env.example` to `.env.local` and update the values for your environment:
+
+```bash
+cp .env.example .env.local
+```
+
+`.env.local` is gitignored and will be loaded automatically by Next.js during development.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:


### PR DESCRIPTION
## Summary
- add `.env.example` for the frontend
- keep `.env.example` out of ignore list
- document copying `.env.example` to `.env.local`

## Testing
- `npm run lint` *(fails: require() style import is forbidden)*
- `npm test` *(fails: Layout tests can't find element)*


------
https://chatgpt.com/codex/tasks/task_e_688a26c95ba08330b737edd1b108db0f