### PR TITLE
Use env vars for OAuth URLs

### DIFF
--- a/band-platform/frontend/.env.example
+++ b/band-platform/frontend/.env.example
@@ -1,4 +1,9 @@
 # Example environment variables for the Next.js frontend
+# Base URL of the backend API. Used for OAuth redirect URIs and all API requests.
 NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# WebSocket endpoint for live features
 NEXT_PUBLIC_WS_URL=ws://localhost:8000/ws
+
+# Google OAuth client ID used when initiating sign in
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=your_google_client_id_here

--- a/band-platform/frontend/README.md
+++ b/band-platform/frontend/README.md
@@ -30,6 +30,11 @@ cp .env.example .env.local
 
 `.env.local` is gitignored and will be loaded automatically by Next.js during development.
 
+Required variables include:
+
+- `NEXT_PUBLIC_API_URL` - Base URL of the backend API (e.g. `http://localhost:8000`).
+- `NEXT_PUBLIC_GOOGLE_CLIENT_ID` - Google OAuth client ID used for sign in.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/band-platform/frontend/src/app/page.tsx
+++ b/band-platform/frontend/src/app/page.tsx
@@ -143,8 +143,19 @@ export default function BandPlatform() {
   };
 
   const handleGoogleSignIn = () => {
-    // Direct Google OAuth sign-in
-    const authUrl = `https://accounts.google.com/o/oauth2/auth?client_id=360999037847-1kkj607098goc38mvurbk91beukr3egn.apps.googleusercontent.com&response_type=code&scope=https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/userinfo.email&redirect_uri=http://localhost:8000/api/auth/google/callback&access_type=offline&prompt=consent`;
+    const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+    if (!clientId || !apiUrl) {
+      console.error('Google OAuth environment variables are not set');
+      return;
+    }
+
+    const redirectUri = `${apiUrl}/api/auth/google/callback`;
+    const authUrl =
+      `https://accounts.google.com/o/oauth2/auth?client_id=${clientId}` +
+      `&response_type=code&scope=https://www.googleapis.com/auth/drive.readonly` +
+      ` https://www.googleapis.com/auth/userinfo.email&redirect_uri=${encodeURIComponent(redirectUri)}` +
+      `&access_type=offline&prompt=consent`;
     window.location.href = authUrl;
   };
 

--- a/band-platform/frontend/src/app/repertoire/page.tsx
+++ b/band-platform/frontend/src/app/repertoire/page.tsx
@@ -141,7 +141,19 @@ export default function RepertoirePage() {
   };
 
   const handleGoogleSignIn = () => {
-    const authUrl = `https://accounts.google.com/o/oauth2/auth?client_id=360999037847-1kkj607098goc38mvurbk91beukr3egn.apps.googleusercontent.com&response_type=code&scope=https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/userinfo.email&redirect_uri=http://localhost:8000/api/auth/google/callback&access_type=offline&prompt=consent`;
+    const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+    if (!clientId || !apiUrl) {
+      console.error('Google OAuth environment variables are not set');
+      return;
+    }
+
+    const redirectUri = `${apiUrl}/api/auth/google/callback`;
+    const authUrl =
+      `https://accounts.google.com/o/oauth2/auth?client_id=${clientId}` +
+      `&response_type=code&scope=https://www.googleapis.com/auth/drive.readonly` +
+      ` https://www.googleapis.com/auth/userinfo.email&redirect_uri=${encodeURIComponent(redirectUri)}` +
+      `&access_type=offline&prompt=consent`;
     window.location.href = authUrl;
   };
 


### PR DESCRIPTION
## Summary
- construct Google OAuth URL in page.tsx and repertoire/page.tsx from `NEXT_PUBLIC_GOOGLE_CLIENT_ID` and `NEXT_PUBLIC_API_URL`
- document required variables in frontend README
- annotate variables in `.env.example`

## Testing
- `npm test` *(fails: Could not locate module @/lib/websocket)*
- `npm run lint` *(fails: ESLint found problems)*

------
https://chatgpt.com/codex/tasks/task_e_688a2a10e0c4833098347754de1c43ee