### PR TITLE
Add frontend Dockerfile.dev for compose build

### DIFF
--- a/band-platform/frontend/Dockerfile.dev
+++ b/band-platform/frontend/Dockerfile.dev
@@ -1,0 +1,17 @@
+FROM node:20-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Install dependencies first to leverage Docker cache
+COPY package*.json ./
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Expose the development port
+EXPOSE 3000
+
+# Run the development server
+CMD ["npm", "run", "dev"]


### PR DESCRIPTION
## Summary
- add a Dockerfile.dev for the Next.js frontend so docker-compose can build the service

## Testing
- `pytest -q` *(fails: RuntimeError: Database not initialized and other failures)*
- `npm test` *(fails to find modules and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a2c2b83e08330875b5196196da54a