### PR TITLE
Add PyJWT dependency and clean requirements

### DIFF
--- a/band-platform/backend/requirements.txt
+++ b/band-platform/backend/requirements.txt
@@ -17,7 +17,7 @@ google-auth-httplib2==0.1.1
 # Authentication & Security
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
-python-multipart==0.0.6
+PyJWT>=2.8
 
 # Data validation and settings
 pydantic==2.5.0


### PR DESCRIPTION
## Summary
- add PyJWT>=2.8 to backend requirements
- remove duplicate `python-multipart` entry

## Testing
- `pip install -r band-platform/backend/requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_688a32faaf8c8330896b6fd2602b2a1d