### PR TITLE
Add member/leader role aliases

### DIFF
--- a/band-platform/backend/app/api/role_helpers.py
+++ b/band-platform/backend/app/api/role_helpers.py
@@ -61,7 +61,7 @@ async def list_available_instruments() -> Dict[str, Dict[str, str]]:
 async def list_available_roles() -> Dict[str, Dict[str, str]]:
     """List all available user roles."""
     roles_info = {
-        UserRole.MUSICIAN: {
+        UserRole.MEMBER: {
             "name": "Musician",
             "description": "Regular band member with access to their instrument-specific content",
             "permissions": [
@@ -70,7 +70,7 @@ async def list_available_roles() -> Dict[str, Dict[str, str]]:
                 "Update own instruments",
             ],
         },
-        UserRole.BAND_LEADER: {
+        UserRole.LEADER: {
             "name": "Band Leader",
             "description": "Band leader with administrative privileges for the band",
             "permissions": [
@@ -93,5 +93,5 @@ async def list_available_roles() -> Dict[str, Dict[str, str]]:
     }
     return {
         "roles": roles_info,
-        "role_hierarchy": [UserRole.MUSICIAN, UserRole.BAND_LEADER, UserRole.ADMIN],
+        "role_hierarchy": [UserRole.MEMBER, UserRole.LEADER, UserRole.ADMIN],
     }

--- a/band-platform/backend/app/models/user.py
+++ b/band-platform/backend/app/models/user.py
@@ -118,7 +118,7 @@ class User(Base):
     @property
     def is_admin(self) -> bool:
         """Check if user has admin privileges."""
-        return self.role in [UserRole.ADMIN, UserRole.BAND_LEADER]
+        return self.role in [UserRole.ADMIN, UserRole.LEADER]
     
     def get_preferred_keys(self) -> List[str]:
         """

--- a/band-platform/backend/tests/test_role_management.py
+++ b/band-platform/backend/tests/test_role_management.py
@@ -79,16 +79,16 @@ class TestRoleUpdate:
     def test_valid_role_update(self):
         """Test creating valid role update."""
         update = RoleUpdate(
-            role=UserRole.BAND_LEADER,
+            role=UserRole.LEADER,
             reorganize_folders=True
         )
         
-        assert update.role == UserRole.BAND_LEADER
+        assert update.role == UserRole.LEADER
         assert update.reorganize_folders is True
     
     def test_default_reorganize_folders(self):
         """Test default value for reorganize_folders."""
-        update = RoleUpdate(role=UserRole.MUSICIAN)
+        update = RoleUpdate(role=UserRole.MEMBER)
         
         assert update.reorganize_folders is False
 
@@ -388,8 +388,8 @@ class TestRoleManagementEndpoints:
         
         # Should have all user roles
         roles = data["roles"]
-        assert UserRole.MUSICIAN in roles
-        assert UserRole.BAND_LEADER in roles
+        assert UserRole.MEMBER in roles
+        assert UserRole.LEADER in roles
         assert UserRole.ADMIN in roles
         
         # Each role should have description and permissions


### PR DESCRIPTION
## Summary
- alias `UserRole.MEMBER`/`LEADER`
- update role helpers and tests to use new aliases
- adjust admin check to use `UserRole.LEADER`

## Testing
- `PYTHONPATH=band-platform/backend pytest band-platform/backend/tests/test_role_management.py::TestRoleManagementEndpoints::test_update_user_role_success -q` *(fails: Database not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_688a369bf7e0833086881154d1fe5aba