### PR TITLE
Add hosting instructions

### DIFF
--- a/online-port.md
+++ b/online-port.md
@@ -1,0 +1,32 @@
+To host the application at your own domain you’d deploy the backend (FastAPI), frontend (Next.js), and supporting services (PostgreSQL, Redis, Celery, etc.) using the provided Docker setup.
+
+Key references from the repository:
+
+* The root README explains how to configure the backend and frontend and how to start the stack with Docker Compose
+* The frontend README suggests deploying the Next.js app using Vercel and outlines environment variable setup
+* The Docker Compose file includes a production-oriented Nginx reverse proxy service mapping ports 80/443 and mounting Nginx configuration files
+
+### Typical steps
+1. **Provision a server or hosting platform**
+   - Choose a VPS or cloud provider capable of running Docker (e.g., AWS EC2, DigitalOcean).
+   - Install Docker and Docker Compose on that server.
+
+2. **Clone the repository and configure environment variables**
+   - From the root directory run the setup steps in `README.md` to create `.env` for the backend and `.env.local` for the frontend.
+   - Update variables like `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_WS_URL`, and the Google OAuth settings to use your domain instead of `localhost`.
+
+3. **Update OAuth redirect URIs and domain settings**
+   - In your Google Cloud console set the OAuth redirect URI to `https://<your-domain>/api/auth/google/callback`.
+   - Ensure the backend `.env` contains that same callback URL.
+
+4. **Configure Nginx and SSL**
+   - The `docker-compose.yml` references volumes `./nginx/nginx.conf` and `./nginx/ssl`. Provide an `nginx.conf` that proxies requests to the frontend (port 3000) and backend (port 8000), and place SSL certificates (e.g., from Let’s Encrypt) in `nginx/ssl`.
+
+5. **Start the stack**
+   - Run `docker-compose up -d` (optionally with the `production` profile) from the project root to build and launch the services—PostgreSQL, Redis, backend, frontend, Celery workers, and Nginx.
+
+6. **Point your domain to the server**
+   - Update your DNS records so your domain points to the server’s IP. Once DNS propagates, Nginx will serve the app over HTTP/HTTPS on that domain.
+
+7. **Optional: deploy frontend on Vercel**
+   - Instead of self-hosting the Next.js frontend, you could deploy it on Vercel using their instructions from `band-platform/frontend/README.md`. You’d still need to host the backend and database somewhere accessible.


### PR DESCRIPTION
## Summary
- add online-port.md with steps to host Soleil on your own domain

## Testing
- `PYTHONPATH=./ pytest -q` *(fails: Database not initialized etc.)*
- `npm test --silent` *(fails: 20 failed, 23 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688a3c83fefc8330bc0c321fb183afa7