### PR TITLE
Fix login flow

### DIFF
--- a/band-platform/backend/start_server.py
+++ b/band-platform/backend/start_server.py
@@ -443,7 +443,7 @@ async def auth_callback(request: Request, code: str = None, error: str = None):
                     json.dump(tokens, f)
                 
                 logger.info(f"Auth callback successful for {user_email}")
-                return RedirectResponse(url=f"{frontend_url}?auth=success")
+                return RedirectResponse(url=f"{frontend_url}/profile?auth=success")
             else:
                 logger.error(f"Failed to get user info: {user_info_response.status_code}")
                 return RedirectResponse(url=f"{frontend_url}?auth=error&message=Failed+to+get+user+info")

--- a/band-platform/backend/tests/__init__.py
+++ b/band-platform/backend/tests/__init__.py
@@ -1,0 +1,9 @@
+
+import os
+import sys
+
+# Ensure backend package is discoverable as 'app'
+TESTS_DIR = os.path.dirname(__file__)
+BACKEND_ROOT = os.path.abspath(os.path.join(TESTS_DIR, '..'))
+if BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, BACKEND_ROOT)

--- a/band-platform/frontend/src/app/dashboard/page.tsx
+++ b/band-platform/frontend/src/app/dashboard/page.tsx
@@ -28,11 +28,11 @@ export default function DashboardPage() {
         if (data.status === 'success') {
           setUser(data.profile);
         } else if (data.message && data.message.includes('Not authenticated')) {
-          router.push('/');
+          router.push('/login');
         }
       } catch (err) {
         console.error('Failed to load profile:', err);
-        router.push('/');
+        router.push('/login');
       } finally {
         setIsLoading(false);
       }

--- a/band-platform/frontend/src/app/login/page.tsx
+++ b/band-platform/frontend/src/app/login/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function LoginPage() {
+  const handleGoogleSignIn = () => {
+    const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+    if (!clientId || !apiUrl) {
+      console.error('Google OAuth environment variables are not set');
+      return;
+    }
+
+    const redirectUri = `${apiUrl}/api/auth/google/callback`;
+    const authUrl =
+      `https://accounts.google.com/o/oauth2/auth?client_id=${clientId}` +
+      `&response_type=code&scope=https://www.googleapis.com/auth/drive.readonly` +
+      ` https://www.googleapis.com/auth/userinfo.email&redirect_uri=${encodeURIComponent(redirectUri)}` +
+      `&access_type=offline&prompt=consent`;
+    window.location.href = authUrl;
+  };
+
+  useEffect(() => {
+    // If redirected back with auth success, go to profile page
+    const urlParams = new URLSearchParams(window.location.search);
+    const authParam = urlParams.get('auth');
+    if (authParam === 'success') {
+      window.location.href = '/profile?auth=success';
+    }
+  }, []);
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center" style={{backgroundColor: '#171717', paddingBottom: '25vh'}}>
+      <div className="max-w-md w-full mx-4">
+        <div className="rounded border p-8 shadow-xl" style={{backgroundColor: '#262626', borderColor: '#404040'}}>
+          <div className="text-center mb-8">
+            <h1 className="text-3xl font-black text-white mb-0">Sole Power <span className="font-thin">Live</span></h1>
+            <p className="text-gray-400 text-sm font-light -mt-1">Assets access</p>
+          </div>
+
+          <div className="text-center">
+            <button
+              onClick={handleGoogleSignIn}
+              className="w-full bg-white hover:bg-gray-100 text-gray-800 font-semibold px-6 py-4 rounded transition-colors flex items-center justify-center shadow-lg"
+            >
+              <svg className="w-5 h-5 mr-3" viewBox="0 0 24 24">
+                <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+              </svg>
+              Sign in with Google
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated login page
- redirect unauthenticated dashboard users to login
- send OAuth callback to the profile setup page
- make backend tests importable by updating test path

## Testing
- `pip install backoff email-validator`
- `pytest -q` *(fails: RuntimeError: Database not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_688bda9f097c8330888f7b8481068a43