### PR TITLE
Fix import in sync engine

### DIFF
--- a/band-platform/backend/app/services/sync_engine.py
+++ b/band-platform/backend/app/services/sync_engine.py
@@ -17,7 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import backoff
 
 from ..database.connection import get_db_session
-from ..models.sync import SyncOperation, SyncStatus
+from ..models.sync import SyncOperation, SyncStatus, GoogleService
 from ..models.user import Band
 from .google_drive import GoogleDriveService
 from .google_sheets import GoogleSheetsService


### PR DESCRIPTION
## Summary
- fix missing `GoogleService` import in sync_engine

## Testing
- `pytest tests/test_sync_engine.py::TestSyncEngineIntegration::test_sync_event_processing -q` *(fails: `AssertionError`)*

------
https://chatgpt.com/codex/tasks/task_e_688bf78a6a28833083dfbbc4b0f374a0