### PR TITLE
Exclude service worker from middleware

### DIFF
--- a/band-platform/frontend/src/middleware.ts
+++ b/band-platform/frontend/src/middleware.ts
@@ -69,6 +69,6 @@ export const config = {
      * - favicon.ico (favicon file)
      * - public files (public directory)
      */
-    '/((?!_next/static|_next/image|favicon.ico|icons|manifest.json).*)',
+    '/((?!_next/static|_next/image|favicon.ico|icons|manifest.json|sw\.js|workbox-.*\.js).*)',
   ],
 };


### PR DESCRIPTION
## Summary
- prevent Next.js middleware from intercepting `sw.js` and `workbox-*.js`

## Testing
- `npm test` *(fails: Could not locate module @/lib/websocket mapped as...)*
- `npm run build`
- manual `navigator.serviceWorker.register('/sw.js')` via Puppeteer

------
https://chatgpt.com/codex/tasks/task_e_688fb0b3aed0833090bc71606e129a36