### PR TITLE
feat: disable trailing slashes

### DIFF
--- a/band-platform/frontend/next.config.ts
+++ b/band-platform/frontend/next.config.ts
@@ -4,7 +4,7 @@ import withPWA from 'next-pwa';
 const nextConfig: NextConfig = {
   /* config options here */
   output: 'standalone',
-  trailingSlash: true,
+  trailingSlash: false,
   images: {
     unoptimized: true
   },


### PR DESCRIPTION
## Summary
- disable `trailingSlash` in Next.js frontend config

## Testing
- `npm test` *(fails: 5 failed, 5 total)*
- `npm run lint` *(fails: A `require()` style import is forbidden, etc.)*
- `npm run build`
- `curl -I http://localhost:3000/login`
- `curl -I http://localhost:3000/dashboard`
- `curl -I http://localhost:3000/profile`

------
https://chatgpt.com/codex/tasks/task_e_688fb4f4bc888330ab2fe443ad07c3f6