### PR TITLE
Normalize middleware public route checks

### DIFF
--- a/band-platform/frontend/src/middleware.ts
+++ b/band-platform/frontend/src/middleware.ts
@@ -4,19 +4,23 @@ import type { NextRequest } from 'next/server';
 export function middleware(request: NextRequest) {
   const { pathname, searchParams } = request.nextUrl;
 
-  const normalizedPathname =
-    pathname !== '/' && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+  const normalizePath = (path: string) =>
+    path !== '/' && path.endsWith('/') ? path.slice(0, -1) : path;
 
-  // Define public routes that don't require authentication
+  const normalizedPathname = normalizePath(pathname);
+
+  // Define public routes that don't require authentication.
+  // To expose a new public route, add its base path (e.g. '/about') to this array.
   const publicRoutes = ['/login'];
 
-  // If accessing login page, always allow it through (no redirects)
-  if (normalizedPathname === '/login') {
-    // If already authenticated, redirect away from login
-    const isAuthenticated = request.cookies.get('soleil_auth') || 
-                           searchParams.get('auth') === 'success';
-    
-    if (isAuthenticated) {
+  const normalizedPublicRoutes = publicRoutes.map(normalizePath);
+  const isPublicRoute = normalizedPublicRoutes.includes(normalizedPathname);
+
+  const isAuthenticated = request.cookies.get('soleil_auth') ||
+                         searchParams.get('auth') === 'success';
+
+  if (isPublicRoute) {
+    if (normalizedPathname === '/login' && isAuthenticated) {
       const hasProfile = request.cookies.get('soleil_profile_complete');
       if (hasProfile) {
         return NextResponse.redirect(new URL('/dashboard', request.url));
@@ -24,18 +28,11 @@ export function middleware(request: NextRequest) {
         return NextResponse.redirect(new URL('/profile', request.url));
       }
     }
-    
-    // Not authenticated - allow access to login page
     return NextResponse.next();
   }
-  
-  // For all other routes, check authentication
-  const isAuthenticated = request.cookies.get('soleil_auth') || 
-                         searchParams.get('auth') === 'success';
-  
+
   // If trying to access a protected route without authentication, redirect to login
-  const isPublicRoute = publicRoutes.includes(normalizedPathname);
-  if (!isPublicRoute && !isAuthenticated) {
+  if (!isAuthenticated) {
     const loginUrl = new URL('/login/', request.url);
     // Only set redirect parameter for meaningful paths
     if (normalizedPathname !== '/') {


### PR DESCRIPTION
## Summary
- Normalize route paths and public route list
- Check public routes via array rather than direct login comparison
- Document how to add new public routes

## Testing
- `npm test` *(fails: 5 failing test suites)*
- `npm run lint` *(fails: ESLint errors in tests and source files)*

------
https://chatgpt.com/codex/tasks/task_e_688fb7d2c9d08330a72cc1a651ee352c