### PR TITLE
Add localhost defaults for CORS and OAuth

### DIFF
--- a/band-platform/backend/.env.example
+++ b/band-platform/backend/.env.example
@@ -1,6 +1,14 @@
+# Development
+# DEBUG=true
+
+# CORS configuration
+# Defaults include https://solepower.live, https://www.solepower.live and localhost variants
+#CORS_ORIGINS=["https://solepower.live","https://www.solepower.live","http://localhost","http://localhost:3000","http://localhost:8000"]
+
 # Google OAuth Configuration
 GOOGLE_CLIENT_ID=your_google_client_id_here
 GOOGLE_CLIENT_SECRET=your_google_client_secret_here
+# When DEBUG=true, this defaults to http://localhost:8000/api/auth/google/callback
 GOOGLE_REDIRECT_URI=http://localhost:8000/api/auth/google/callback
 
 # Google Drive Configuration

--- a/band-platform/backend/README_SECURITY.md
+++ b/band-platform/backend/README_SECURITY.md
@@ -12,7 +12,8 @@ For security reasons, OAuth credentials and API keys are not included in the rep
 2. Edit `.env` and add your credentials:
    - `GOOGLE_CLIENT_ID`: Your Google OAuth2 client ID
    - `GOOGLE_CLIENT_SECRET`: Your Google OAuth2 client secret
-   - `GOOGLE_REDIRECT_URI`: Should be `http://localhost:8000/api/auth/google/callback` for local development
+   - `GOOGLE_REDIRECT_URI`: Defaults to the production callback but falls back to `http://localhost:8000/api/auth/google/callback` when `DEBUG=true`
+   - `CORS_ORIGINS`: Defaults include `https://solepower.live`, `https://www.solepower.live`, and localhost variants (`http://localhost`, `http://localhost:3000`, `http://localhost:8000`)
    - `GOOGLE_DRIVE_SOURCE_FOLDER_ID`: The ID of your Google Drive folder containing charts
 
 ## Files Not in Repository

--- a/band-platform/backend/app/config.py
+++ b/band-platform/backend/app/config.py
@@ -5,6 +5,7 @@ This module uses pydantic-settings for environment variable management
 following the PRP requirements for Google API credentials and JWT settings.
 """
 
+import os
 from pydantic import Field, ConfigDict
 from pydantic_settings import BaseSettings
 from dotenv import load_dotenv
@@ -67,7 +68,11 @@ class Settings(BaseSettings):
         description="Google OAuth 2.0 Client Secret",
     )
     google_redirect_uri: str = Field(
-        default="https://solepower.live/api/auth/google/callback",
+        default_factory=lambda: (
+            "http://localhost:8000/api/auth/google/callback"
+            if os.getenv("DEBUG", "false").lower() == "true"
+            else "https://solepower.live/api/auth/google/callback"
+        ),
         description="Google OAuth redirect URI"
     )
     

--- a/band-platform/backend/start_server.py
+++ b/band-platform/backend/start_server.py
@@ -37,8 +37,11 @@ app = FastAPI(
     version="1.0.0"
 )
 
-# CORS - Updated for production
-cors_origins = os.getenv('CORS_ORIGINS', '["https://solepower.live", "https://www.solepower.live"]')
+# CORS - Updated for production and local development
+cors_origins = os.getenv(
+    'CORS_ORIGINS',
+    '["https://solepower.live", "https://www.solepower.live", "http://localhost", "http://localhost:3000", "http://localhost:8000"]'
+)
 if isinstance(cors_origins, str):
     import json
     cors_origins = json.loads(cors_origins)


### PR DESCRIPTION
## Summary
- Allow http://localhost origins by default in backend start script
- Use localhost redirect URI when DEBUG is true
- Document default CORS origins and OAuth redirect behavior

## Testing
- `pytest` *(fails: 26 failed, 136 passed, 6 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688fb95a1d80833087703649d7ed7ef7