### PR TITLE
feat: add service account support for Google Drive access

### DIFF
--- a/band-platform/docker-compose.production.yml
+++ b/band-platform/docker-compose.production.yml
@@ -56,6 +56,7 @@ services:
       - PORT=8000
     volumes:
       - ./storage:/app/storage
+      - /etc/soleil/service-account-key.json:/etc/soleil/service-account-key.json:ro
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
- Mount service account key file in Docker container
- Configure backend to use service account for shared band Drive access
- No longer requires individual user Drive permissions

The service account provides read-only access to the shared band Google Drive folder, allowing all band members to access charts and audio without needing their own Drive permissions.

🤖 Generated with [Claude Code](https://claude.ai/code)